### PR TITLE
feat: use name var instead of prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A terraform module to setup OpenVPN on GCP.
 ```hcl
 module "openvpn" {
   source     = "../modules/terraform-openvpn-gcp"
+  name       = var.name
   region     = var.region
   project_id = var.project_id
   network    = module.vpc.network
@@ -34,7 +35,7 @@ Full contributing guidelines are covered [here](CONTRIBUTING.md).
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.11.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.12.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
@@ -73,10 +74,10 @@ No modules.
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels, provided as a map | `map` | `{}` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map | `map` | `{}` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name to use when generating resources | `any` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | The name or self\_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | `string` | `"default"` | no |
 | <a name="input_network_tier"></a> [network\_tier](#input\_network\_tier) | Network network\_tier | `string` | `"STANDARD"` | no |
 | <a name="input_output_dir"></a> [output\_dir](#input\_output\_dir) | Folder to store all user openvpn details | `string` | `"openvpn"` | no |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | prefix to use for all resource | `string` | `""` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP Project ID | `any` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The GCP Project Region | `any` | `null` | no |
 | <a name="input_remote_user"></a> [remote\_user](#input\_remote\_user) | The user to operate as on the VM. SSH Key is generated for this user | `string` | `"ubuntu"` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
   private_key_file = "private-key.pem"
   # adding the null_resource to prevent evaluating this until the openvpn_update_users has executed
   refetch_user_ovpn = null_resource.openvpn_update_users_script.id != "" ? !alltrue([for x in var.users : fileexists("${var.output_dir}/${x}.ovpn")]) : false
-  prefix            = var.prefix == "" ? "" : "${var.prefix}-"
+  name              = var.name == "" ? "" : "${var.name}-"
   access_config = [{
     nat_ip       = google_compute_address.default.address
     network_tier = var.network_tier
@@ -19,7 +19,7 @@ locals {
 }
 
 resource "google_compute_firewall" "allow-external-ssh" {
-  name    = "allow-external-ssh-${var.network}"
+  name    = "openvpn-${var.name}-allow-external-ssh"
   network = var.network
 
   allow {
@@ -32,7 +32,7 @@ resource "google_compute_firewall" "allow-external-ssh" {
 }
 
 resource "google_compute_address" "default" {
-  name         = "global-openvpn-ip-${var.network}"
+  name         = "openvpn-${var.name}-global-ip"
   region       = var.region
   network_tier = var.network_tier
 }
@@ -59,7 +59,7 @@ resource "random_id" "password" {
 
 // Use a persistent disk so that it can be remounted on another instance.
 resource "google_compute_disk" "this" {
-  name  = "${var.network}-disk"
+  name  = "openvpn-${var.name}-disk"
   image = var.image_family
   size  = var.disk_size_gb
   type  = var.disk_type
@@ -70,7 +70,7 @@ resource "google_compute_disk" "this" {
 # Instance Template
 #-------------------
 resource "google_compute_instance_template" "tpl" {
-  name_prefix  = "${var.network}-"
+  name_prefix  = "openvpn-${var.name}-"
   project      = var.project_id
   machine_type = var.machine_type
   labels       = var.labels
@@ -125,7 +125,7 @@ resource "google_compute_instance_template" "tpl" {
 }
 
 resource "google_compute_instance_from_template" "this" {
-  name    = "openvpn-${var.network}"
+  name    = "openvpn-${var.name}"
   project = var.project_id
   zone    = var.zone
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 resource "google_compute_firewall" "allow-external-ssh" {
-  name    = "${local.prefix}openvpn-allow-external-ssh"
+  name    = "allow-external-ssh-${var.network}"
   network = var.network
 
   allow {
@@ -32,7 +32,7 @@ resource "google_compute_firewall" "allow-external-ssh" {
 }
 
 resource "google_compute_address" "default" {
-  name         = "${local.prefix}global-openvpn-ip"
+  name         = "global-openvpn-ip-${var.network}"
   region       = var.region
   network_tier = var.network_tier
 }
@@ -59,7 +59,7 @@ resource "random_id" "password" {
 
 // Use a persistent disk so that it can be remounted on another instance.
 resource "google_compute_disk" "this" {
-  name  = "${local.prefix}-disk"
+  name  = "${var.network}-disk"
   image = var.image_family
   size  = var.disk_size_gb
   type  = var.disk_type
@@ -70,7 +70,7 @@ resource "google_compute_disk" "this" {
 # Instance Template
 #-------------------
 resource "google_compute_instance_template" "tpl" {
-  name_prefix  = "${local.prefix}-"
+  name_prefix  = "${var.network}-"
   project      = var.project_id
   machine_type = var.machine_type
   labels       = var.labels
@@ -125,7 +125,7 @@ resource "google_compute_instance_template" "tpl" {
 }
 
 resource "google_compute_instance_from_template" "this" {
-  name    = "${local.prefix}openvpn"
+  name    = "openvpn-${var.network}"
   project = var.project_id
   zone    = var.zone
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
-variable "prefix" {
-  description = "prefix to use for all resource"
-  default     = ""
-}
 variable "project_id" {
   description = "The GCP Project ID"
   default     = null
+}
+
+variable "name" {
+  description = "The name to use when generating resources"
 }
 
 variable "region" {


### PR DESCRIPTION
- Make the name of the resources in the module to reflect the VPC network where the module is being deployed to.
- Add an optional input -- name to the module