### PR TITLE
Fix openvpn download configurations trigger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ $ git commit -m "<MESSAGE>" # calls pre-commit hooks before commiting changes
 
 ## Semantic Pull Requests
 
-To generate changelog, Pull Requests or Commits must have sementic and must follow conventional specs below:
+To generate changelog, Pull Requests or Commits must have semantic and must follow conventional specs below:
 
 - `feat:` for new features
 - `fix:` for bug fixes

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Full contributing guidelines are covered [here](CONTRIBUTING.md).
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.12.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.1.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.14.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.2.2 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.2 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
 ## Modules

--- a/main.tf
+++ b/main.tf
@@ -205,7 +205,7 @@ resource "null_resource" "openvpn_update_users_script" {
 # Download user configurations to output_dir
 resource "null_resource" "openvpn_download_configurations" {
   triggers = {
-    trigger = timestamp()
+    trigger = join(",", var.users)
   }
 
   depends_on = [null_resource.openvpn_update_users_script]


### PR DESCRIPTION
- The `openvpn_download_configurations` resource always results in replacement when running `terraform apply`. 
```
# module.openvpn.null_resource.openvpn_download_configurations is tainted, so must be replaced
-/+ resource "null_resource" "openvpn_download_configurations" {
      ~ id       = "3073341639751670051" -> (known after apply)
      ~ triggers = {
          - "trigger" = "2021-10-05T09:44:17Z"
        } -> (known after apply)
    }
```

- Changed the trigger from a timestamp to only download when there is a change in the list of users, whether a new user is added or removed.
    
    