### PR TITLE
fix: Remove $ sign from custom dns export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.0](https://github.com/DeimosCloud/terraform-google-openvpn/compare/v2.1.1...v2.2.0) (2022-04-04)
+
+
+### Features
+
+* Add custom DNS Server configuration ([#16](https://github.com/DeimosCloud/terraform-google-openvpn/issues/16)) ([8dbb452](https://github.com/DeimosCloud/terraform-google-openvpn/commit/8dbb452975eb88e64cee00542b1dc1b9d51e54ae))
+
 ### [2.1.1](https://github.com/DeimosCloud/terraform-google-openvpn/compare/v2.1.0...v2.1.1) (2022-03-24)
 
 

--- a/main.tf
+++ b/main.tf
@@ -86,10 +86,10 @@ resource "google_compute_instance_template" "tpl" {
     export PASS=1
     # Using Custom DNS
     export DNS=13
-    export $DNS1="${var.dns_servers[0]}"
-    %{if length(var.dns_servers) > 1}
-    export $DNS2="${var.dns_servers[1]}"
-    %{endif}
+    export DNS1="${var.dns_servers[0]}"
+    %{if length(var.dns_servers) > 1~}
+    export DNS2="${var.dns_servers[1]}"
+    %{endif~}
     /home/${var.remote_user}/openvpn-install.sh
   SCRIPT
 

--- a/variables.tf
+++ b/variables.tf
@@ -116,7 +116,7 @@ variable "dns_servers" {
   default     = ["8.8.8.8", "8.8.4.4"]
   type        = list(string)
   validation {
-    condition     = length(var.dns_servers) < 1 || length(var.dns_servers) > 2
+    condition     = length(var.dns_servers) >= 1 || length(var.dns_servers) <= 2
     error_message = "The variable 'var.dns_servers' should be an array with 1 or 2 DNS entries only."
   }
 }


### PR DESCRIPTION
## [2.2.0](https://github.com/DeimosCloud/terraform-google-openvpn/compare/v2.1.1...v2.2.0) (2022-04-04)

### Features

* Add custom DNS Server configuration ([#16](https://github.com/DeimosCloud/terraform-google-openvpn/issues/16)) ([8dbb452](https://github.com/DeimosCloud/terraform-google-openvpn/commit/8dbb452975eb88e64cee00542b1dc1b9d51e54ae))