### PR TITLE
Fix the incorrect revoke of a users when users are revoked

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,7 @@ resource "google_compute_instance_template" "tpl" {
 
   metadata_startup_script = <<SCRIPT
     curl -O ${var.install_script_url}
+    sed -i.bak 's/ifconfig\.co/ifconfig\.me/g' openvpn-install.sh
     chmod +x openvpn-install.sh
     mv openvpn-install.sh /home/${var.remote_user}/
     chown ${var.remote_user}:${var.remote_user} /home/${var.remote_user}/openvpn-install.sh

--- a/scripts/update_users.sh
+++ b/scripts/update_users.sh
@@ -51,7 +51,7 @@ do
     export CLIENT="${ovpn_user}"
     export DNS="9"
     searchRegex="${ovpn_user}$"
-    export CLIENTNUMBER=$(echo $(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '|grep -n $searchRegex)|head -c 1)
+    export CLIENTNUMBER=$(echo $(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '|grep -n $searchRegex)| awk '{print $2}')
     ./openvpn-install.sh
   fi
 done


### PR DESCRIPTION
Basically when you remove a user from the OpenVPN list the update_users.sh script will run the below commands:

```
for ovpn_user in ${ovpn_users[@]}
do
  if [[ "$USERNAMES" =~ "$ovpn_user" ]];
  then
    echo "Keeping certificate for user ${ovpn_user}."
  else
    echo "Revoking certificate for user ${ovpn_user}!"

    # Export the corresponding options and revoke the user certificate
    export MENU_OPTION="2"
    export CLIENT="${ovpn_user}"
    export DNS="9"
    searchRegex="${ovpn_user}$"
    export CLIENTNUMBER=$(echo $(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '|grep -n $searchRegex)|head -c 1)
    ./openvpn-install.sh
  fi
done
```
Now the issue comes in with this command:
```
export CLIENTNUMBER=$(echo $(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '|grep -n $searchRegex)|head -c 1)
```

To break this down, this section of the command will return a list of users in the order they are in OpenVPN as a user with a number assigned to it and then select the one that it’s currently looping through skip or remove the user. To remove a user in OpenVPN you don’t pass in a name you pass in the number the user has assigned to it.

So let’s break this down further, this section of the command returns the list of users and the number:
```
tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ' '
     1 user1
     2 user2
     3 user3
     4 user4
     5 user5
     6 user6
     7 user7
     8 user8
     9 user9
    10 user10
    11 user11
    12 user12
```

Next we filter down to a user, so let’s take the user1:
```
tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ' ' | grep -n user1
```
This will return:
```
1: 1 user1
```
If we add the head -c 1 to the command it will return:
```
1
```
Now the problem comes when you remove a user which lets say is user 12 in the list as an example:
```
tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ' ' | grep -n user12 | head -c 1
```

This is also going to return 1 due to head -c 1 only taking the first value, if we were using head -c 2  it would return user 12 but that is not scalable and users in the single digits would return number:
 like 1: or 8:

With the current design:

If we remove user 12 from the list  what is going to happen is that it’s going to leave user 12 and remove user 1 If there was 20 users and we remove user 20 what is going to happen is it will remove user 2

The solution to this problem is instead of using head -c 1

We filter by column 2 which will always return the correct number by using awk '{print $2}':
```
tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ' ' | grep -n user12 | awk '{print $2}'
```
Will return:
```
12
```
This will allow the users to be able to scale single digits, double digits, triple digits etc…